### PR TITLE
feat: Add instructions for a Kubernetes 'platform'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,216 @@
 # do-k8s
+
+Configuration-as-code and documentation for a little Kubernetes platform.
+
+The "Kubernetes platform" consists of:
+
+- A Kubernetes cluster, of course, running on [DigitalOcean Kubernetes].
+- An [NGINX Ingress Controller] to handle host-based routing of Ingress resources, backed by a [DigitalOcean load balancer].
+- [ExternalDNS] to allow managing DNS records from within Kubernetes.
+- [cert-manager] to automatically provision and renew certificates for Ingress TLS hosts.
+
+The total cost for this setup, based on the included [cluster definition], is $30/month ($20/month for a 4GB, 2 vCPU droplet; $10/month for the load balancer).
+
+## Usage
+
+The following steps should ultimately be scripted.
+In the mean time, it should be possible to follow the steps in order, copying and pasting snippets, in order to bring up a cluster with all the platform componentry running.
+
+### Prerequisites
+
+In order to follow these instructions you'll need the following installed and on your `PATH`:
+- The [DigitalOcean CLI].
+- The [Kubernetes CLI].
+- [`jq`].
+
+
+### Choose a name
+
+The cluster in Digital Ocean Kubernetes needs a name.
+Furthermore, we need a domain name under which DNS entires should be created by ExternalDNS.
+
+The snippets below will assume the following variables are set with the desired names (they do not need to be exported):
+
+- **`cluster_name`**: The name for the DigitalOcean Kubernetes cluster.
+- **`cluster_domain`**: The DigitalOcean Domain to use for external DNS.
+
+For example:
+
+```sh
+cluster_name='default'
+cluster_domain='connec.co.uk'
+```
+
+### Create a cluster
+
+Now we can create the cluster.
+
+```sh
+readarray -t cluster_args < <(cat config/cluster-args.json | jq -r '.[]')
+doctl kubernetes clusters create "$cluster_name" "${cluster_args[@]}"
+```
+
+This will take some time.
+Once it has completed, your kubeconfig will be updated and you should be able to list everything running on the cluster by default:
+
+```sh
+kubectl get pods --all-namespaces
+```
+
+They should all be `Running`.
+
+### Deploy the NGINX ingress controller
+
+The NGINX Ingress Controller project maintains Kubernetes manifests that can be used to deploy the ingress controller:
+
+```sh
+version=0.28.0
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-$version/deploy/static/mandatory.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-$version/deploy/static/provider/cloud-generic.yaml
+```
+
+This will crate a bunch of Kubernetes resources, including a `LoadBalancer` service.
+The cluster will provision a DigitalOcean Load Balancer for this service, which may take some time.
+You can monitor progress by watching:
+
+```sh
+kubectl --namespace ingress-nginx get services ingress-nginx
+```
+
+Unfortunately, there is a complex [compatibility issue] involving cert-manager, NGINX ingress, and Kubernetes networking which ultimately means that the default service configuration will not work properly for requests from inside the cluster.
+This is required for cert-manager to perform its 'self-testing' of challenges, and these cannot be disabled.
+
+Thankfully, there is a workaround that involves configuring a DNS record for the ingress service and applying an annotation that causes the DigitalOcean load balancer to set the service's ingress status to the DNS name, rather than an IP.
+This then bypasses an optimisation in the Kubernetes networking and ensures that requests from within the cluster are still routed through the load balancer, and so the ingress controller works as desired.
+
+Sadly, we cannot use ExternalDNS to configure this DNS record since that would create a circular reference: by setting the hostname of the service and the hostname for the load balancer to the same value, ExternalDNS would try to create a `CNAME` from the DNS record to itself.
+This needs to be worked around by adding the ingress DNS record manually with `doctl`.
+
+The following snippet can be used to apply the workaround:
+
+```sh
+load_balancer_id="$(kubectl --namespace ingress-nginx get services ingress-nginx --output json \
+  | jq -r '.metadata.annotations["kubernetes.digitalocean.com/load-balancer-id"]')"
+ingress_ip="$(doctl compute load-balancer get "$load_balancer_id" --output json \
+  | jq -r 'first | .ip')"
+doctl compute domain records create "$cluster_domain" \
+  --record-type A \
+  --record-name ingress-nginx \
+  --record-data "$ingress_ip"
+kubectl --namespace ingress-nginx annotate services ingress-nginx \
+  --overwrite \
+  "service.beta.kubernetes.io/do-loadbalancer-hostname=ingress-nginx.$cluster_domain"
+```
+
+**Note:** a side effect of this approach is that DNS records created by ExternalDNS will be `CNAME`s to the ingress DNS record.
+
+### Deploy ExternalDNS
+
+ExternalDNS allows us to manage DNS records from within Kubernetes by annotating services or ingresses.
+There are a lot of configuration options for ExternalDNS, and the following have been chosen for simplicity and consistency:
+
+- Only ingress resources will be used as sources for DNS names.
+- Ingress resources that want external DNS entries should be annotated with `external-dns: ''`.
+- Only subdomains of the cluster domain will be managed.
+- `TXT` records will be used to track ownership of DNS records, and the cluster's ID will be used as
+  the 'owner ID'.
+  `TXT` records will be prefixed with `_`.
+- The functional DNS records will all be `CNAME`s to the ingress domain, due to the workaround required for cert-manager.
+
+ExternalDNS requires a DigitalOcean access token with write access in order to manage DNS entries.
+The recommendation is to create one named "ExternalDNS (&lt;cluster ID&gt;)".
+The following snippet will look up the cluster ID and request an access token:
+
+```sh
+cluster_id="$(doctl kubernetes clusters get "$cluster_name" --output json \
+  | jq -r 'first | .id')"
+{
+  read -rsp "Access token for ExternalDNS ($cluster_id): " external_dns_access_token
+  echo >&2
+  external_dns_access_token_base64="$(printf '%s' "$external_dns_access_token" | base64)"
+}
+```
+
+We can now deploy the ExernalDNS Kubernetes manifest:
+
+```sh
+external_dns="$(cat config/external-dns.yaml)"
+for var in cluster_domain cluster_id external_dns_access_token_base64; do
+  external_dns="$(echo "$external_dns" | sed "s/\$$var/${!var}/")"
+done
+echo "$external_dns" | kubectl apply -f -
+```
+
+This will create several Kubernetes resources.
+You can check that the ExternalDNS agent started correctly with:
+
+```sh
+kubectl -n external-dns logs -l app=external-dns
+```
+
+### Deploy cert-manager
+
+The final component of the platform is cert-manager, which allows the Kubernetes cluster to provision TLS certificates based on the demands of ingress resources.
+Thankfully, with the above changes in place for the ingress controller, the installation can be performed with few surprises.
+
+Firstly, install cert-manager into the cluster using the official manifest:
+
+```sh
+version=v0.13.0
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/$version/cert-manager.yaml
+```
+
+This will create a slew of Kubernetes custom resource definitions and resources.
+Check the cert-manager deployment is running smoothly with:
+
+```sh
+kubectl --namespace cert-manager logs -l app=cert-manager
+```
+
+We can then create issuers for Lets Encrypt using the included Kubernetes manifest:
+
+```sh
+{
+  read -p 'Email to use with Lets Encrypt: ' lets_encrypt_email
+  cat config/cluster-issuers.yaml \
+    | sed "s/\$lets_encrypt_email/$lets_encrypt_email/" \
+    | kubectl apply -f -
+}
+```
+
+### Test the platform
+
+Finally, we can test the platform!
+Deploy the included test Kubernetes manifest:
+
+```sh
+cat config/test.yaml \
+  | sed "s/\$cluster_domain/$cluster_domain/" \
+  | kubectl apply -f -
+```
+
+It may take a minute or two for everything to provision, but very soon you should be able to cURL `https://test.$cluster_domain` and see the text `OK`:
+
+```sh
+$ curl https://test.$cluster_domain
+OK
+```
+
+Once satisfied, clean up the test:
+
+```sh
+kubectl delete -f config/test.yaml
+```
+
+And you're done.
+
+[DigitalOcean Kubernetes]: https://www.digitalocean.com/products/kubernetes/
+[NGINX Ingress Controller]: https://kubernetes.github.io/ingress-nginx/
+[DigitalOcean load balancer]: https://www.digitalocean.com/products/load-balancer/
+[ExternalDNS]: https://github.com/kubernetes-sigs/external-dns
+[cert-manager]: https://cert-manager.io/
+[cluster definition]: config/cluster-args.json
+[DigitalOcean CLI]: https://github.com/digitalocean/doctl#installing-doctl
+[Kubernetes CLI]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
+[`jq`]: https://stedolan.github.io/jq/download/
+[compatibility issue]: https://github.com/jetstack/cert-manager/issues/863#issuecomment-567062996

--- a/config/cluster-args.json
+++ b/config/cluster-args.json
@@ -1,0 +1,5 @@
+[
+  "--region=lon1",
+  "--version=1.16.2-do.3",
+  "--node-pool=name=default;size=s-2vcpu-4gb;count=1"
+]

--- a/config/cluster-issuers.yaml
+++ b/config/cluster-issuers.yaml
@@ -1,0 +1,31 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+ name: letsencrypt-staging
+ namespace: cert-manager
+spec:
+ acme:
+   server: https://acme-staging-v02.api.letsencrypt.org/directory
+   email: $lets_encrypt_email
+   privateKeySecretRef:
+     name: letsencrypt-staging
+   solvers:
+   - http01:
+       ingress:
+         class: nginx
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+  namespace: cert-manager
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: $lets_encrypt_email
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+    - http01:
+        ingress:
+          class: nginx

--- a/config/external-dns.yaml
+++ b/config/external-dns.yaml
@@ -1,0 +1,109 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-dns
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: external-dns
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["extensions"]
+  resources: ["ingresses"]
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  namespace: external-dns
+  name: external-dns
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: external-dns
+  name: external-dns
+data:
+  domain-name: $cluster_domain
+  owner-id: $cluster_id
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: external-dns
+  name: external-dns
+data:
+  access-token: $external_dns_access_token_base64
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: external-dns
+  name: external-dns
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: external-dns
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      serviceAccountName: external-dns
+      containers:
+      - name: external-dns
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.18
+        env:
+        - name: DOMAIN_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: external-dns
+              key: domain-name
+        - name: DO_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: external-dns
+              key: access-token
+        - name: EXTERNAL_DNS_PROVIDER
+          value: digitalocean
+        - name: EXTERNAL_DNS_SOURCE
+          value: ingress
+        - name: EXTERNAL_DNS_DOMAIN_FILTER
+          value: $(DOMAIN_NAME)
+        - name: EXTERNAL_DNS_ANNOTATION_FILTER
+          value: external-dns
+        - name: EXTERNAL_DNS_TXT_PREFIX
+          value: _
+        - name: EXTERNAL_DNS_TXT_OWNER_ID
+          valueFrom:
+            configMapKeyRef:
+              name: external-dns
+              key: owner-id

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+spec:
+  ports:
+  - port: 80
+    targetPort: 5678
+  selector:
+    app: test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - name: test
+        image: hashicorp/http-echo
+        args:
+        - "-text=OK"
+        ports:
+        - containerPort: 5678
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: test
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    external-dns: ''
+spec:
+  tls:
+  - hosts:
+    - test.$cluster_domain
+    secretName: test-tls
+  rules:
+  - host: test.$cluster_domain
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: test
+          servicePort: 80


### PR DESCRIPTION
This is mostly just README documentation, with a few supporting
configuration files. Ultimately the content of the README could probably
be turned into a robust script, but I can't be bothered with that right
now.