### PR TITLE
feat: Update versions, suffix external DNS, use DNS solvers

### DIFF
--- a/config/cluster-args.json
+++ b/config/cluster-args.json
@@ -1,5 +1,5 @@
 [
   "--region=lon1",
-  "--version=1.16.2-do.3",
+  "--version=1.16.6-do.2",
   "--node-pool=name=default;size=s-2vcpu-4gb;count=1"
 ]

--- a/config/cluster-issuers.yaml
+++ b/config/cluster-issuers.yaml
@@ -1,18 +1,31 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: solver-dns
+  namespace: cert-manager
+data:
+  access-token: $cert_manager_access_token_base64
+---
 apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
  name: letsencrypt-staging
  namespace: cert-manager
 spec:
- acme:
-   server: https://acme-staging-v02.api.letsencrypt.org/directory
-   email: $lets_encrypt_email
-   privateKeySecretRef:
-     name: letsencrypt-staging
-   solvers:
-   - http01:
-       ingress:
-         class: nginx
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: $lets_encrypt_email
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+    - dns01:
+        digitalocean:
+          tokenSecretRef:
+            name: solver-dns
+            key: access-token
+      selector:
+        dnsZones:
+        - $cluster_domain
 ---
 apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
@@ -26,6 +39,11 @@ spec:
     privateKeySecretRef:
       name: letsencrypt-prod
     solvers:
-    - http01:
-        ingress:
-          class: nginx
+    - dns01:
+        digitalocean:
+          tokenSecretRef:
+            name: solver-dns
+            key: access-token
+      selector:
+        dnsZones:
+        - $cluster_domain

--- a/config/external-dns.yaml
+++ b/config/external-dns.yaml
@@ -15,10 +15,7 @@ metadata:
   name: external-dns
 rules:
 - apiGroups: [""]
-  resources: ["services"]
-  verbs: ["get","watch","list"]
-- apiGroups: [""]
-  resources: ["pods"]
+  resources: ["services","endpoints","pods"]
   verbs: ["get","watch","list"]
 - apiGroups: ["extensions"]
   resources: ["ingresses"]
@@ -44,7 +41,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: external-dns
-  name: external-dns
+  name: external-dns-$cluster_domain_dns_label
 data:
   domain-name: $cluster_domain
   owner-id: $cluster_id
@@ -53,7 +50,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   namespace: external-dns
-  name: external-dns
+  name: external-dns-$cluster_domain_dns_label
 data:
   access-token: $external_dns_access_token_base64
 ---
@@ -61,7 +58,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: external-dns
-  name: external-dns
+  name: external-dns-$cluster_domain_dns_label
 spec:
   replicas: 1
   selector:
@@ -80,17 +77,17 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.18
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.7.1
         env:
         - name: DOMAIN_NAME
           valueFrom:
             configMapKeyRef:
-              name: external-dns
+              name: external-dns-$cluster_domain_dns_label
               key: domain-name
         - name: DO_TOKEN
           valueFrom:
             secretKeyRef:
-              name: external-dns
+              name: external-dns-$cluster_domain_dns_label
               key: access-token
         - name: EXTERNAL_DNS_PROVIDER
           value: digitalocean
@@ -105,5 +102,5 @@ spec:
         - name: EXTERNAL_DNS_TXT_OWNER_ID
           valueFrom:
             configMapKeyRef:
-              name: external-dns
+              name: external-dns-$cluster_domain_dns_label
               key: owner-id


### PR DESCRIPTION
Versions for Kubernetes, ingress controller, ExternalDNS, and
cert-manager have all been updated.

Additionally, the ExternalDNS deployment now suffixes its resources with
the cluster domain in order to simplify the addition of other
ExternalDNS deployments for other domain names.

Finally, DNS solvers are now used for cert-manager. This removes a
synchronisation step (challenge ingress -> ExternalDNS -> DNS) which can
cut down the resolution time. It does require an additional access token
to be supplied.