### PR TITLE
feat: Change external DNS policy to 'sync'

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -8,6 +8,7 @@ cert-manager:
       enabled: true
 
 external-dns:
+  policy: sync
   provider: digitalocean
   txtPrefix: _
   sources:


### PR DESCRIPTION
This will cause DNS entries managed by external DNS to be deleted when they are no longer used in the cluster (e.g. when the source Ingress resource is deleted).

Fixes #4.